### PR TITLE
refactor: 단어 sort기준 강화

### DIFF
--- a/src/utils/word/index.ts
+++ b/src/utils/word/index.ts
@@ -6,7 +6,10 @@ export const sortWordList = (searchText: string, wordList?: IDiseaseItem[]): IDi
     const aIndex = a.sickNm.indexOf(searchText);
     const bIndex = b.sickNm.indexOf(searchText);
     if (aIndex > bIndex) return 1;
-    if (aIndex === bIndex && a.sickNm.length > b.sickNm.length) return 1;
+    if (aIndex === bIndex) {
+      if (a.sickNm.length > b.sickNm.length) return 1;
+      if (a.sickNm > b.sickNm) return 1;
+    }
     return -1;
   });
 };


### PR DESCRIPTION
# 정렬 기준 강화

[수정 반영 된 배포 사이트](https://deploy-preview-13--1a-search-clinical-trial.netlify.app/)

## 수정 전,
sort 비교 조건이 강력하지 않아 매 랜더마다 sort결과가 다른 문제가 존재.
**하지만, 로컬에서는 문제가 발견되지 않으며 netlify를 통해 배포를 하면 문제가 발생**
(배포환경이 영향을 미치는 것 같다.)

https://user-images.githubusercontent.com/64524916/169664401-87ef00d1-9230-45a6-8589-5a97fca2d9d5.mov

## 수정 후,
이 문제에 대해 깊게 고민할 필요는 없었다.
간단하게 기준을 강화하면 된다.
길이 비교에 마무리되지 않는다면(길이가 같은 경우) 단어 자체를 비교한다.

https://user-images.githubusercontent.com/64524916/169664413-3797eea5-8b9e-42a7-869b-7e3eb0ddb82e.mov


